### PR TITLE
Implement the transactional outbox pattern using Kafka

### DIFF
--- a/src/main/java/com/jane/ecommerce/application/payment/outbox/PaymentOutboxFacade.java
+++ b/src/main/java/com/jane/ecommerce/application/payment/outbox/PaymentOutboxFacade.java
@@ -1,0 +1,43 @@
+package com.jane.ecommerce.application.payment.outbox;
+
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutbox;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxService;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxStatus;
+import com.jane.ecommerce.infrastructure.messaging.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentOutboxFacade {
+
+    private final PaymentOutboxService paymentOutboxService;
+    private final KafkaProducer kafkaProducer;
+
+    @Value("${e-commerce-api.payment.topic-name}")
+    private String topicName;
+
+    @Transactional
+    public void retryOutboxMessage(LocalDateTime targetDatetime) {
+        List<PaymentOutbox> outboxList = paymentOutboxService.findAllByStatusAndUpdatedAtBefore(PaymentOutboxStatus.INIT, targetDatetime);
+
+        if (outboxList.isEmpty()) {
+            return;
+        }
+
+        for (PaymentOutbox outbox : outboxList) {
+            if (outbox.getCount() >= 3) {
+                paymentOutboxService.save(outbox.failed());
+                continue;
+            }
+
+            kafkaProducer.sendMessage(topicName, outbox.getId(), outbox.getMessage());
+            paymentOutboxService.save(outbox.incrementCount());
+        }
+    }
+}

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutbox.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutbox.java
@@ -1,0 +1,41 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PaymentOutbox {
+    private final String id;
+    private final String message;
+    private PaymentOutboxStatus status;
+    private int count;
+
+    public static PaymentOutbox init(String message) {
+        return PaymentOutbox.builder()
+                .id(UUID.randomUUID().toString())
+                .message(message)
+                .status(PaymentOutboxStatus.INIT)
+                .count(0)
+                .build();
+    }
+
+    public PaymentOutbox published() {
+        this.status = PaymentOutboxStatus.PUBLISHED;
+        return this;
+    }
+
+    public PaymentOutbox failed() {
+        this.status = PaymentOutboxStatus.FAIL;
+        return this;
+    }
+
+    public PaymentOutbox incrementCount() {
+        this.count = this.count + 1;
+        return this;
+    }
+}

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxEntity.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxEntity.java
@@ -39,10 +39,12 @@ public class PaymentOutboxEntity extends BaseEntity {
                 .build();
     }
 
-    public static PaymentOutboxEntity toEntity(PaymentOutbox outbox) {
-        return new PaymentOutboxEntity(outbox.getId(),
+    public static PaymentOutboxEntity from(PaymentOutbox outbox) {
+        return new PaymentOutboxEntity(
+                outbox.getId(),
                 outbox.getMessage(),
                 outbox.getStatus(),
-                outbox.getCount());
+                outbox.getCount()
+        );
     }
 }

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxEntity.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxEntity.java
@@ -1,0 +1,48 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import com.jane.ecommerce.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "payment_outbox")
+@Entity
+public class PaymentOutboxEntity extends BaseEntity {
+    @Id
+    private String id;
+
+    @Column(columnDefinition = "longtext")
+    private String message;
+
+    private PaymentOutboxStatus status;
+
+    private int count;
+
+    public PaymentOutboxEntity(String id, String message, PaymentOutboxStatus status, int count) {
+        this.id = id;
+        this.message = message;
+        this.status = status;
+        this.count = count;
+    }
+
+    public PaymentOutbox toDomain() {
+        return PaymentOutbox.builder()
+                .id(this.id)
+                .message(this.message)
+                .status(this.status)
+                .count(this.count)
+                .build();
+    }
+
+    public static PaymentOutboxEntity toEntity(PaymentOutbox outbox) {
+        return new PaymentOutboxEntity(outbox.getId(),
+                outbox.getMessage(),
+                outbox.getStatus(),
+                outbox.getCount());
+    }
+}

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxRepository.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxRepository.java
@@ -1,0 +1,13 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentOutboxRepository {
+
+    PaymentOutbox save(PaymentOutbox outbox);
+
+    PaymentOutbox findById(String id);
+
+    List<PaymentOutbox> findAllByStatusAndUpdatedAtBefore(PaymentOutboxStatus status, LocalDateTime targetDatetime);
+}

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxService.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxService.java
@@ -1,0 +1,28 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class PaymentOutboxService {
+
+    private final PaymentOutboxRepository paymentOutboxRepository;
+
+    @Transactional
+    public PaymentOutbox save(PaymentOutbox outbox) {
+        return paymentOutboxRepository.save(outbox);
+    }
+
+    public PaymentOutbox findById(String id) {
+        return paymentOutboxRepository.findById(id);
+    }
+
+    public List<PaymentOutbox> findAllByStatusAndUpdatedAtBefore(PaymentOutboxStatus status, LocalDateTime targetDatetime) {
+        return paymentOutboxRepository.findAllByStatusAndUpdatedAtBefore(status, targetDatetime);
+    }
+}

--- a/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxStatus.java
+++ b/src/main/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxStatus.java
@@ -1,0 +1,12 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentOutboxStatus {
+    INIT,
+    PUBLISHED,
+    FAIL
+}

--- a/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxJpaRepository.java
+++ b/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxJpaRepository.java
@@ -1,0 +1,13 @@
+package com.jane.ecommerce.infrastructure.persistence.payment.outbox;
+
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxEntity;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentOutboxJpaRepository extends JpaRepository<PaymentOutboxEntity, String> {
+
+    List<PaymentOutboxEntity> findAllByStatusAndUpdatedAtBefore(PaymentOutboxStatus status, LocalDateTime updatedAt);
+}

--- a/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxRepositoryImpl.java
@@ -20,7 +20,7 @@ public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
 
     @Override
     public PaymentOutbox save(PaymentOutbox outbox) {
-        return paymentOutboxJpaRepository.save(PaymentOutboxEntity.toEntity(outbox)).toDomain();
+        return paymentOutboxJpaRepository.save(PaymentOutboxEntity.from(outbox)).toDomain();
     }
 
     @Override

--- a/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/jane/ecommerce/infrastructure/persistence/payment/outbox/PaymentOutboxRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.jane.ecommerce.infrastructure.persistence.payment.outbox;
+
+import com.jane.ecommerce.domain.error.CustomException;
+import com.jane.ecommerce.domain.error.ErrorCode;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutbox;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxEntity;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxRepository;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
+
+    private final PaymentOutboxJpaRepository paymentOutboxJpaRepository;
+
+    @Override
+    public PaymentOutbox save(PaymentOutbox outbox) {
+        return paymentOutboxJpaRepository.save(PaymentOutboxEntity.toEntity(outbox)).toDomain();
+    }
+
+    @Override
+    public PaymentOutbox findById(String id) {
+        return paymentOutboxJpaRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, new String[]{ id }))
+                .toDomain();
+    }
+
+    @Override
+    public List<PaymentOutbox> findAllByStatusAndUpdatedAtBefore(PaymentOutboxStatus status, LocalDateTime targetDatetime) {
+        return paymentOutboxJpaRepository.findAllByStatusAndUpdatedAtBefore(status, targetDatetime).stream()
+                .map(PaymentOutboxEntity::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/com/jane/ecommerce/interfaces/listener/KafkaConsumer.java
+++ b/src/main/java/com/jane/ecommerce/interfaces/listener/KafkaConsumer.java
@@ -1,15 +1,52 @@
 package com.jane.ecommerce.interfaces.listener;
 
+import com.jane.ecommerce.domain.error.CustomException;
+import com.jane.ecommerce.domain.error.ErrorCode;
+import com.jane.ecommerce.domain.order.Order;
+import com.jane.ecommerce.domain.order.OrderClient;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutbox;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
 @Slf4j
+@RequiredArgsConstructor
 @Service
 public class KafkaConsumer {
-    @KafkaListener(topics = "my-topic", groupId = "${spring.application.name}")
+
+    private final PaymentOutboxService paymentOutboxService;
+    private final OrderClient orderClient;
+
+    @KafkaListener(topics = "${e-commerce-api.test.topic-name}", groupId = "${spring.application.name}")
     public void consumeMessage(ConsumerRecord<String, Object> record) {
         log.info("Received message: {} with key: {}", record.value(), record.key());
+    }
+
+    // 1. 셀프 컨슈밍하는 리스너
+    @KafkaListener(topics = "${e-commerce-api.payment.topic-name}", groupId = "payment-outbox")
+    public void checkOutbox(ConsumerRecord<String, Object> record) {
+        log.info("[payment-outbox] Received message: {} with key: {}", record.value(), record.key());
+
+        // 아웃박스 데이터 읽으면서 상태 변경 update
+        PaymentOutbox outbox = paymentOutboxService.findById(record.key());
+        paymentOutboxService.save(outbox.published());
+    }
+
+    // 2. 비즈니스 로직 하는 리스너
+    @KafkaListener(topics = "${e-commerce-api.payment.topic-name}", groupId = "send-process")
+    public void send(ConsumerRecord<String, Object> record) throws InterruptedException {
+        log.info("[send-process] Received message: {} with key: {}", record.value(), record.key());
+        Order order = (Order) record.value();
+        orderClient.send(order);
+
+        // 주문 정보를 외부 데이터 플랫폼으로 전송
+        boolean isSent = orderClient.send(order);
+
+        if (!isSent) {
+            throw new CustomException(ErrorCode.CONFLICT);
+        }
     }
 }

--- a/src/main/java/com/jane/ecommerce/interfaces/listener/PaymentProcessedListener.java
+++ b/src/main/java/com/jane/ecommerce/interfaces/listener/PaymentProcessedListener.java
@@ -1,11 +1,14 @@
 package com.jane.ecommerce.interfaces.listener;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jane.ecommerce.application.payment.PaymentProcessedEvent;
-import com.jane.ecommerce.domain.error.CustomException;
-import com.jane.ecommerce.domain.error.ErrorCode;
 import com.jane.ecommerce.domain.order.Order;
-import com.jane.ecommerce.domain.order.OrderClient;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutbox;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxService;
+import com.jane.ecommerce.infrastructure.messaging.KafkaProducer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -15,18 +18,27 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class PaymentProcessedListener {
 
-    private final OrderClient orderClient;
+    private final PaymentOutboxService paymentOutboxService;
+    private final KafkaProducer kafkaProducer;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${e-commerce-api.payment.topic-name}")
+    private String topicName;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void createOutbox(PaymentProcessedEvent event) throws JsonProcessingException {
+        Order order = event.getOrder();
+
+        // 아웃박스 엔티티 에다가 이벤트 정보를 저장한다.
+        paymentOutboxService.save(PaymentOutbox.init(objectMapper.writeValueAsString(order)));
+    }
 
     @Async // 비동기 처리
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 트랜잭션 커밋 후에 실행
-    public void handlePaymentProcessedEvent(PaymentProcessedEvent event) {
+    public void producePaymentProcessMessage(PaymentProcessedEvent event) {
         Order order = event.getOrder();
 
-        // 주문 정보를 외부 데이터 플랫폼으로 전송
-        boolean isSent = orderClient.send(order);
-
-        if (!isSent) {
-            throw new CustomException(ErrorCode.CONFLICT);
-        }
+        // 이벤트를 produce 한다.
+        kafkaProducer.sendMessage(topicName, order.getId().toString(), order);
     }
 }

--- a/src/main/java/com/jane/ecommerce/interfaces/scheduler/KafkaScheduler.java
+++ b/src/main/java/com/jane/ecommerce/interfaces/scheduler/KafkaScheduler.java
@@ -1,0 +1,22 @@
+package com.jane.ecommerce.interfaces.scheduler;
+
+import com.jane.ecommerce.application.payment.outbox.PaymentOutboxFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaScheduler {
+
+    private final PaymentOutboxFacade paymentOutboxFacade;
+
+    // 5분마다 실행
+    @Scheduled(cron = "0 */5 * * * *")
+    public void run() {
+        // 스케줄러로 아웃박스 테이블에서 상태가 미전송인걸 확인해서 재발송 (=브로커에 메세지를 다시 produce) 한다.
+        paymentOutboxFacade.retryOutboxMessage(LocalDateTime.now().minusMinutes(5));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,8 @@ spring:
       ack-mode: manual
 
 e-commerce-api:
+  payment:
+    topic-name: local.commerce.payment-process-event.v1
   test:
     topic-name: test-topic
 

--- a/src/test/java/com/jane/ecommerce/KafkaTest.java
+++ b/src/test/java/com/jane/ecommerce/KafkaTest.java
@@ -1,8 +1,21 @@
 package com.jane.ecommerce;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicReference;
+
+import com.jane.ecommerce.domain.coupon.Coupon;
+import com.jane.ecommerce.domain.coupon.UserCoupon;
+import com.jane.ecommerce.domain.order.Order;
+import com.jane.ecommerce.domain.order.OrderClient;
+import com.jane.ecommerce.domain.order.OrderStatus;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxService;
+import com.jane.ecommerce.domain.payment.outbox.PaymentOutboxStatus;
+import com.jane.ecommerce.domain.user.User;
+import com.jane.ecommerce.infrastructure.messaging.KafkaProducer;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -12,18 +25,38 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 public class KafkaTest {
-    private static final String TOPIC = "test";
+    private static final String TOPIC_TEST = "test";
+    private static final String TOPIC_PRODUCER_TEST = "producer.test";
     private static final AtomicInteger counter = new AtomicInteger(0);
     private static final AtomicReference<String> receivedMessage = new AtomicReference<>(); // 수신된 메시지 저장
 
     @Autowired
     private KafkaTemplate<String, Object> producer;
 
-    @KafkaListener(topics = TOPIC)
+    @Autowired
+    private KafkaProducer kafkaProducer;
+
+    @Autowired
+    private PaymentOutboxService paymentOutboxService;
+
+    @Autowired
+    private OrderClient orderClient;
+
+    @Value("${e-commerce-api.payment.topic-name}")
+    private String topicName;
+
+    @KafkaListener(topics = TOPIC_TEST)
     public void listen(String message) {
+        counter.incrementAndGet(); // 리스너가 호출되면 1 증가
+        receivedMessage.set(message); // 수신된 메시지 저장
+    }
+
+    @KafkaListener(topics = TOPIC_PRODUCER_TEST)
+    public void listenProducer(String message) {
         counter.incrementAndGet(); // 리스너가 호출되면 1 증가
         receivedMessage.set(message); // 수신된 메시지 저장
     }
@@ -31,7 +64,7 @@ public class KafkaTest {
     @Test
     void kafkaTest() {
         String expectedMessage = "Hello, Jane!";
-        producer.send(TOPIC, expectedMessage);
+        producer.send(TOPIC_TEST, expectedMessage);
 
         await() // 검증될 때 까지 기다린다.
                 .pollInterval(Duration.ofMillis(300)) // 300ms 마다 한 번씩
@@ -42,6 +75,49 @@ public class KafkaTest {
 
                     assertThat(counter.get()).isEqualTo(1L);
                     assertThat(receivedMessage.get().replaceAll("^\"|\"$", "")).isEqualTo(expectedMessage); // 메시지 일치 여부 확인
+                });
+    }
+
+    @Test
+    void kafkaProducerTest() {
+        kafkaProducer.sendMessage(TOPIC_PRODUCER_TEST, "test-1", "Hello, Jane!");
+
+        await() // 검증될 때 까지 기다린다.
+                .pollInterval(Duration.ofMillis(300)) // 300ms 마다 한 번씩
+                .atMost(Duration.ofSeconds(2)) // 최대 2s 까지
+                .untilAsserted(() -> { // 아래 모든 assertion 이 만족할 때 까지
+                    System.out.println("counter.get() = " + counter.get());
+                    assertThat(counter.get()).isEqualTo(1L);
+                });
+    }
+
+    @Test
+    void kafkaPaymentProcessEventTest() {
+
+        User user = User.create("jane", "password", BigDecimal.valueOf(1000L));
+        Coupon coupon = Coupon.create("code-1", 10L, LocalDateTime.of(2025, 12, 31, 23, 59, 59), 1);
+        UserCoupon userCoupon = UserCoupon.create(user, coupon, false);
+
+        Order order = Order.create(
+                user,
+                userCoupon,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                OrderStatus.COMPLETED
+        );
+
+        kafkaProducer.sendMessage(topicName, "test-2", order);
+
+        await() // 검증될 때 까지 기다린다.
+                .pollInterval(Duration.ofMillis(300)) // 300ms 마다 한 번씩
+                .atMost(Duration.ofSeconds(2)) // 최대 2s 까지
+                .untilAsserted(() -> { // 아래 모든 assertion 이 만족할 때 까지
+
+                    // 아웃박스 데이터 상태 변경 확인
+                    assertThat(paymentOutboxService.findById("test-2").getStatus()).isEqualTo(PaymentOutboxStatus.PUBLISHED);
+
+                    // 주문 정보 외부 데이터 플랫폼 전송 로직 호출 검증
+                    verify(orderClient).send(order);
                 });
     }
 }

--- a/src/test/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxTest.java
+++ b/src/test/java/com/jane/ecommerce/domain/payment/outbox/PaymentOutboxTest.java
@@ -1,0 +1,46 @@
+package com.jane.ecommerce.domain.payment.outbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentOutboxTest {
+
+    private PaymentOutbox paymentOutbox;
+
+    @BeforeEach
+    void setup() {
+        paymentOutbox = PaymentOutbox.init("Test Message");
+    }
+
+    @Test
+     void testInit() {
+        assertNotNull(paymentOutbox.getId());
+        assertEquals("Test Message", paymentOutbox.getMessage());
+        assertEquals(PaymentOutboxStatus.INIT, paymentOutbox.getStatus());
+        assertEquals(0, paymentOutbox.getCount());
+    }
+
+    @Test
+    void testPublished() {
+        paymentOutbox.published();
+        assertEquals(PaymentOutboxStatus.PUBLISHED, paymentOutbox.getStatus());
+    }
+
+    @Test
+    void testFailed() {
+        paymentOutbox.failed();
+        assertEquals(PaymentOutboxStatus.FAIL, paymentOutbox.getStatus());
+    }
+
+    @Test
+    void testIncrementCnt() {
+        paymentOutbox.incrementCount();
+        assertEquals(1, paymentOutbox.getCount());
+    }
+}


### PR DESCRIPTION
## PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->
본 PR 은 결제 완료 후 외부 데이터 플랫폼에 주문 정보를 전송하는 ApplicationEvent 기반의 로직을 Kafka 의 Message 발행으로 개선하는 작업을 포함합니다.
Kafka 의 메세지 발행이 실패하는 것을 방지하기 위해 Transactional Outbox Pattern 을 적용하였으며, Self-consuming 방식으로 이벤트를 처리하도록 구성하였습니다.
발행이 실패한 케이스에 대하여 스케줄러를 이용한 재처리 로직을 구현하였습니다.

- 결제 완료 이벤트를 위한 아웃박스 엔티티 및 로직 셋팅 ( 07f0a7b )
- 결제 완료 이벤트 리스너에서 아웃박스에 이벤트 정보 저장 및 Broker 에 메세지 전송, 컨슈머에서 메세지 수신 ( d5533bc )
- 아웃박스 엔티티에서 미전송 건 조회하여 재처리 ( b1ce017 )
- 카프카 메시지 송수신 통합 테스트 작성 ( c85936f )

구현한 내용을 정리하여 함께 드립니다.

**상세 프로세스**
1. `PaymentProcessedUsecase.execute()` 시 `PaymentProcessedEvent` 발생
2. `PaymentProcessedListenter` 수행
  a. `createOutbox`
      - PaymentOutbox 엔티티에 이벤트 정보를 저장
      - BEFORE_COMMIT, 오류 시 Rollback
  b. `producePaymentProcessMessage`
      - `KafkaProducer` 가 Broker 에 메세지 전송 ( Topic Name : `${e-commerce-api.payment.topic-name}` )
      - AFTER_COMMIT, 비동기 처리
3. `KafkaConsumer` 에서 메세지를 읽어옴 ( Topic Name : `${e-commerce-api.payment.topic-name}` )
  a. groupId : "payment-outbox"
      - 셀프 컨슈밍하는 리스너
      - 아웃박스 데이터 읽으면서 상태 변경 update
  b. groupId : "send-process"
      - 비즈니스 로직 하는 리스너
      - 주문 정보를 외부 데이터 플랫폼으로 전송
4. `KafkaScheduler`
    - 5분마다 스케줄러가 실행되며 아웃박스 테이블에서 상태가 미전송인걸 확인해서 재발송(=Broker 에 메세지를 다시 produce) 한다.

**아웃박스 엔티티 ( `PaymentOutboxEntity` )**
- `id` : UUID
- `message` : payload
- `status` : INIT, PUBLISHED, FAIL
- `count` : 시도 횟수

**아웃박스 도메인 ( `PaymentOutbox` )**
- `init()` : 아웃박스에 정보 담기
- `published()` : 카프카에 전송 완료
- `failed()` : 카프카에 전송 실패
- `incrementCount()` : 재시도 횟수 증가

## 리뷰 포인트
<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
-->
- 추후 모든 개발이 완료되면 각 도메인을 분리하여 이벤트 기반으로 개선하고, 각각의 서비스로 빌드해보고 싶은 마음이 있습니다.
msa 로 서비스를 구성한다면 보통 현업에서 프로젝트 레포지토리나 패키지 구조를 어떻게 구성하고 형상관리를 하시는지 궁금합니다.
  - 서비스 단위로 github repository 를 아예 분리해서 관리하시는지,
  - 아니면 github repository 하나에 각 서비스를 여러 개의 모듈(? 패키지?)로 관리하시는지,
  - 정하기 나름이라면 요즘은 어떤 방식이 더 선호되고 있는지 의견 부탁드립니다. 
- 상단에 작성한 **상세 프로세스** 가 잘 구성된 Transactional Outbox Pattern 인지 검토 요청드립니다.
- Kafka 셋팅 위주로 하느라 아키텍처가 엉망인 것 같은데... 검토 부탁드립니다.

## Definition of Done (DoD)
<!--
    DOD 란 해당 작업을 완료했다고 간주하기 위해 충족해야 하는 기준을 의미합니다.
    어떤 기능을 위해 어떤 요구사항을 만족하였으며, 어떤 테스트를 수행했는지 등을 명확하게 체크리스트로 기재해 주세요.
    리뷰어 입장에서, 모든 맥락을 파악하기 이전에 작업의 성숙도/완성도를 파악하는 데에 도움이 됩니다.
    만약 계획되거나 연관 작업이나 파생 작업이 존재하는데, 이후로 미뤄지는 경우 TODO -, 사유와 함께 적어주세요.

    ex:
    - [x] 상품 도메인 모델 구조 설계 완료 ( [정책 참고자료](관련 문서 링크) )
    - [x] 상품 재고 차감 로직 유닛/통합 테스트 완료
    - [ ] TODO - 상품 주문 로직 개발 ( 정책 미수립으로 인해 후속 작업에서 진행 )
-->

- [x] 이벤트 리스너로 PaymentOutbox 엔티티에 정보 저장( BEFORE_COMMIT ) , Kafka Broker 에 메세지 전송 ( AFTER_COMMIT ) 구현
- [x] 아웃박스 도메인 단위 테스트 작성
- [x] 카프카 컨슈머로 1) 셀프 컨슈밍, 2) 비즈니스 로직 리스너 구현
- [x] 아웃박스에서 실패 건 재발송 스케줄러 구현
- [x] 카프카 메시지 송수신 통합 테스트 작성